### PR TITLE
search-100-times

### DIFF
--- a/.github/workflows/generate-search-string.yaml
+++ b/.github/workflows/generate-search-string.yaml
@@ -1,11 +1,9 @@
-# This workflow generates a string to be searched for in the GHA UI
-
 name: Generate 120 times `Foo is not Bar`
 
 on:
   push:
   schedule:
-    - cron: '35 2 * * 7'
+    - cron: '30 5 * * 1,3'
   workflow_dispatch:
     inputs:
       counter:


### PR DESCRIPTION
#### Generate a search string
This PR generates search-string `Foo is not Bar`  between 100 and 120 times. 
Searching in the GHA run log only finds the first 100 occurrences! 
#### :warning:  It's not a feature: It's a bug  